### PR TITLE
Restructured did registry to support eth signing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1119,8 +1119,8 @@ checksum = "2fd0db749597d91ff862fd1d55ea87f7855a744a8425a64695b6fca237d1dad1"
 
 [[package]]
 name = "sol-did"
-version = "3.0.0"
-source = "git+https://github.com/identity-com/sol-did?rev=b0a32154aa7d2d42666865a90356e9c50616dca2#b0a32154aa7d2d42666865a90356e9c50616dca2"
+version = "3.1.1"
+source = "git+https://github.com/identity-com/sol-did?rev=be43638398a92235a8b4831649edc50b381565cc#be43638398a92235a8b4831649edc50b381565cc"
 dependencies = [
  "anchor-lang",
  "bitflags",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,8 @@
         "@project-serum/anchor": "^0.25.0"
     },
     "devDependencies": {
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/wallet": "^5.7.0",
         "@project-serum/anchor-cli": "https://github.com/kklas/anchor-nightly/releases/download/anchor-cli-latest/anchor-cli-0.25.0-7eb8ca8.tgz",
         "@types/bn.js": "^5.1.0",
         "@types/chai": "^4.3.0",

--- a/programs/did-registry/Cargo.toml
+++ b/programs/did-registry/Cargo.toml
@@ -17,4 +17,4 @@ default = []
 
 [dependencies]
 anchor-lang = { version = "0.25.0", features = ["init-if-needed"] }
-sol-did = { git = "https://github.com/identity-com/sol-did", rev = "b0a32154aa7d2d42666865a90356e9c50616dca2", features = ["no-entrypoint"] }
+sol-did = { git = "https://github.com/identity-com/sol-did", rev = "be43638398a92235a8b4831649edc50b381565cc", features = ["no-entrypoint"] }

--- a/programs/did-registry/src/eth_signing.rs
+++ b/programs/did-registry/src/eth_signing.rs
@@ -1,0 +1,29 @@
+use crate::ErrorCode;
+use anchor_lang::prelude::*;
+use sol_did::{
+    state::Secp256k1RawSignature,
+    utils::{convert_secp256k1pub_key_to_address, eth_verify_message},
+};
+
+pub fn validate_eth_signature(
+    message: &[u8],
+    eth_signature: &Secp256k1RawSignature,
+    expected_address: &[u8],
+) -> Result<()> {
+    let secp256k1_pubkey = eth_verify_message(
+        message,
+        0u64, // We do not use a nonce here - there is no risk of replay when adding a DID to a registry
+        eth_signature.signature,
+        eth_signature.recovery_id,
+    )
+    .map_err(|_| ErrorCode::InvalidEthSignature)?;
+
+    // Check the recovered address matches the expected address
+    let address = convert_secp256k1pub_key_to_address(&secp256k1_pubkey);
+
+    // use this instead of require_eq! because the latter requires the Display trait on its arguments
+    match address == expected_address {
+        true => Ok(()),
+        false => Err(ErrorCode::WrongEthSigner.into()),
+    }
+}

--- a/scripts/util/solana.ts
+++ b/scripts/util/solana.ts
@@ -1,6 +1,11 @@
 import os from "os";
 import { Registry } from "../../src";
-import { Connection, Keypair, Transaction } from "@solana/web3.js";
+import {
+  Connection,
+  Keypair,
+  Transaction,
+  clusterApiUrl,
+} from "@solana/web3.js";
 
 const secretKey = require(os.homedir() + "/.config/solana/id.json");
 const keypair = Keypair.fromSecretKey(Buffer.from(secretKey));
@@ -20,7 +25,7 @@ const toWallet = (keypair: Keypair) => ({
 export const registry = new Registry(
   toWallet(keypair),
   new Connection(
-    process.env.RPC_URL || "https://api.devnet.solana.com",
+    process.env.RPC_URL || clusterApiUrl("mainnet-beta"),
     "confirmed"
   )
 );

--- a/src/types/did_registry.ts
+++ b/src/types/did_registry.ts
@@ -1,435 +1,671 @@
 export type DidRegistry = {
-  version: "0.1.0";
-  name: "did_registry";
-  instructions: [
+  "version": "0.1.0",
+  "name": "did_registry",
+  "instructions": [
     {
-      name: "createKeyRegistry";
-      accounts: [
+      "name": "createKeyRegistry",
+      "docs": [
+        "Create an empty DID registry for a given solana key"
+      ],
+      "accounts": [
         {
-          name: "registry";
-          isMut: true;
-          isSigner: false;
+          "name": "registry",
+          "isMut": true,
+          "isSigner": false
         },
         {
-          name: "authority";
-          isMut: true;
-          isSigner: true;
+          "name": "authority",
+          "isMut": true,
+          "isSigner": true
         },
         {
-          name: "systemProgram";
-          isMut: false;
-          isSigner: false;
+          "name": "systemProgram",
+          "isMut": false,
+          "isSigner": false
         }
-      ];
-      args: [
+      ],
+      "args": [
         {
-          name: "bump";
-          type: "u8";
+          "name": "bump",
+          "type": "u8"
         }
-      ];
+      ]
     },
     {
-      name: "registerDid";
-      accounts: [
+      "name": "registerDid",
+      "docs": [
+        "Add a DID to an authority's registry"
+      ],
+      "accounts": [
         {
-          name: "registry";
-          isMut: true;
-          isSigner: false;
+          "name": "registry",
+          "isMut": true,
+          "isSigner": false
         },
         {
-          name: "authority";
-          isMut: false;
-          isSigner: true;
-          docs: ["The authority that owns the registry"];
+          "name": "authority",
+          "isMut": false,
+          "isSigner": true,
+          "docs": [
+            "The authority that owns the registry"
+          ]
         },
         {
-          name: "did";
-          isMut: false;
-          isSigner: false;
-          docs: [
-            'The DID to add to the registry. This is the did "identifier", not the did account',
+          "name": "did",
+          "isMut": false,
+          "isSigner": false,
+          "docs": [
+            "The DID to add to the registry. This is the did \"identifier\", not the did account",
             "i.e. did:sol:<identifier>",
             "note - this may or may not be the same as the authority."
-          ];
+          ]
         },
         {
-          name: "didAccount";
-          isMut: false;
-          isSigner: false;
-          docs: [
+          "name": "didAccount",
+          "isMut": false,
+          "isSigner": false,
+          "docs": [
             "The account containing the DID document",
             "Specifically, the did account is checked to see if it has the authority as a signer",
             "Since it can be a generative DID, we do not use Account<DidAccount> here"
-          ];
+          ]
         }
-      ];
-      args: [
+      ],
+      "args": [
         {
-          name: "didBump";
-          type: "u8";
+          "name": "didBump",
+          "type": "u8"
         }
-      ];
+      ]
     },
     {
-      name: "removeDid";
-      accounts: [
+      "name": "removeDid",
+      "docs": [
+        "Remove a DID from an authority's registry"
+      ],
+      "accounts": [
         {
-          name: "registry";
-          isMut: true;
-          isSigner: false;
+          "name": "registry",
+          "isMut": true,
+          "isSigner": false
         },
         {
-          name: "authority";
-          isMut: false;
-          isSigner: true;
-          docs: ["The authority that owns the registry"];
+          "name": "authority",
+          "isMut": false,
+          "isSigner": true,
+          "docs": [
+            "The authority that owns the registry"
+          ]
         },
         {
-          name: "did";
-          isMut: false;
-          isSigner: false;
-          docs: ["The DID to remove from the registry"];
+          "name": "did",
+          "isMut": false,
+          "isSigner": false,
+          "docs": [
+            "The DID to remove from the registry"
+          ]
         }
-      ];
-      args: [];
+      ],
+      "args": []
     },
     {
-      name: "registerDidForEthAddress";
-      accounts: [
+      "name": "registerDidForEthAddress",
+      "docs": [
+        "Add a DID to an eth address's registry, if the solana signer is also an authority"
+      ],
+      "accounts": [
         {
-          name: "registry";
-          isMut: true;
-          isSigner: false;
+          "name": "registry",
+          "isMut": true,
+          "isSigner": false
         },
         {
-          name: "authority";
-          isMut: true;
-          isSigner: true;
+          "name": "authority",
+          "isMut": true,
+          "isSigner": true
         },
         {
-          name: "did";
-          isMut: false;
-          isSigner: false;
-          docs: [
-            'The DID to add to the registry. This is the did "identifier", not the did account',
+          "name": "did",
+          "isMut": false,
+          "isSigner": false,
+          "docs": [
+            "The DID to add to the registry. This is the did \"identifier\", not the did account",
             "i.e. did:sol:<identifier>",
             "note - this may or may not be the same as the authority."
-          ];
+          ]
         },
         {
-          name: "didAccount";
-          isMut: false;
-          isSigner: false;
-          docs: [
+          "name": "didAccount",
+          "isMut": false,
+          "isSigner": false,
+          "docs": [
             "The account containing the DID document",
             "Specifically, the did account is checked to see if it has the authority as a signer",
             "Since it can be a generative DID, we do not use Account<DidAccount> here"
-          ];
+          ]
         },
         {
-          name: "systemProgram";
-          isMut: false;
-          isSigner: false;
+          "name": "systemProgram",
+          "isMut": false,
+          "isSigner": false
         }
-      ];
-      args: [
+      ],
+      "args": [
         {
-          name: "ethAddress";
-          type: {
-            array: ["u8", 20];
-          };
+          "name": "ethAddress",
+          "type": {
+            "array": [
+              "u8",
+              20
+            ]
+          }
         },
         {
-          name: "didBump";
-          type: "u8";
+          "name": "didBump",
+          "type": "u8"
         }
-      ];
-    }
-  ];
-  accounts: [
+      ]
+    },
     {
-      name: "keyRegistry";
-      type: {
-        kind: "struct";
-        fields: [
-          {
-            name: "version";
-            type: "u8";
-          },
-          {
-            name: "authority";
-            type: "publicKey";
-          },
-          {
-            name: "dids";
-            type: {
-              vec: "publicKey";
-            };
+      "name": "registerDidSignedByEthAddress",
+      "docs": [
+        "Add a DID to an eth address's registry, without requiring the solana signer to be an authority on the DID"
+      ],
+      "accounts": [
+        {
+          "name": "registry",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "payer",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "did",
+          "isMut": false,
+          "isSigner": false,
+          "docs": [
+            "The DID to add to the registry. This is the did \"identifier\", not the did account",
+            "i.e. did:sol:<identifier>",
+            "note - this may or may not be the same as the payer."
+          ]
+        },
+        {
+          "name": "didAccount",
+          "isMut": false,
+          "isSigner": false,
+          "docs": [
+            "The account containing the DID document",
+            "This can safely be a DidAccount, rather than UncheckedAccount,",
+            "since, for the DID to include an eth address it must be a non-generative DID."
+          ]
+        },
+        {
+          "name": "systemProgram",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "ethAddress",
+          "type": {
+            "array": [
+              "u8",
+              20
+            ]
           }
-        ];
-      };
-    },
-    {
-      name: "controllerRegistry";
-      type: {
-        kind: "struct";
-        fields: [
-          {
-            name: "version";
-            type: "u8";
-          },
-          {
-            name: "did";
-            type: "publicKey";
-          },
-          {
-            name: "controlledDids";
-            type: {
-              vec: "publicKey";
-            };
+        },
+        {
+          "name": "ethSignature",
+          "type": {
+            "defined": "Secp256k1RawSignature"
           }
-        ];
-      };
+        },
+        {
+          "name": "didBump",
+          "type": "u8"
+        }
+      ]
     }
-  ];
-  errors: [
+  ],
+  "accounts": [
     {
-      code: 6000;
-      name: "DIDError";
-      msg: "An error occurred evaluating the DID";
+      "name": "keyRegistry",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "version",
+            "type": "u8"
+          },
+          {
+            "name": "authority",
+            "type": "publicKey"
+          },
+          {
+            "name": "dids",
+            "type": {
+              "vec": "publicKey"
+            }
+          }
+        ]
+      }
     },
     {
-      code: 6001;
-      name: "NotAuthority";
-      msg: "The key is not an authority on the DID";
-    },
-    {
-      code: 6002;
-      name: "DIDRegistered";
-      msg: "The DID is already registered";
-    },
-    {
-      code: 6003;
-      name: "DIDNotRegistered";
-      msg: "Attempt to remove a DID that is not registered";
+      "name": "controllerRegistry",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "version",
+            "type": "u8"
+          },
+          {
+            "name": "did",
+            "type": "publicKey"
+          },
+          {
+            "name": "controlledDids",
+            "type": {
+              "vec": "publicKey"
+            }
+          }
+        ]
+      }
     }
-  ];
+  ],
+  "types": [
+    {
+      "name": "Secp256k1RawSignature",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "signature",
+            "type": {
+              "array": [
+                "u8",
+                64
+              ]
+            }
+          },
+          {
+            "name": "recoveryId",
+            "type": "u8"
+          }
+        ]
+      }
+    }
+  ],
+  "errors": [
+    {
+      "code": 6000,
+      "name": "DIDError",
+      "msg": "An error occurred evaluating the DID"
+    },
+    {
+      "code": 6001,
+      "name": "NotAuthority",
+      "msg": "The key is not an authority on the DID"
+    },
+    {
+      "code": 6002,
+      "name": "DIDRegistered",
+      "msg": "The DID is already registered"
+    },
+    {
+      "code": 6003,
+      "name": "DIDNotRegistered",
+      "msg": "Attempt to remove a DID that is not registered"
+    },
+    {
+      "code": 6004,
+      "name": "InvalidEthSignature",
+      "msg": "The Eth signature did not sign the message"
+    },
+    {
+      "code": 6005,
+      "name": "WrongEthSigner",
+      "msg": "The Eth signature was signed by the wrong address"
+    }
+  ]
 };
 
 export const IDL: DidRegistry = {
-  version: "0.1.0",
-  name: "did_registry",
-  instructions: [
+  "version": "0.1.0",
+  "name": "did_registry",
+  "instructions": [
     {
-      name: "createKeyRegistry",
-      accounts: [
-        {
-          name: "registry",
-          isMut: true,
-          isSigner: false,
-        },
-        {
-          name: "authority",
-          isMut: true,
-          isSigner: true,
-        },
-        {
-          name: "systemProgram",
-          isMut: false,
-          isSigner: false,
-        },
+      "name": "createKeyRegistry",
+      "docs": [
+        "Create an empty DID registry for a given solana key"
       ],
-      args: [
+      "accounts": [
         {
-          name: "bump",
-          type: "u8",
+          "name": "registry",
+          "isMut": true,
+          "isSigner": false
         },
+        {
+          "name": "authority",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "systemProgram",
+          "isMut": false,
+          "isSigner": false
+        }
       ],
+      "args": [
+        {
+          "name": "bump",
+          "type": "u8"
+        }
+      ]
     },
     {
-      name: "registerDid",
-      accounts: [
+      "name": "registerDid",
+      "docs": [
+        "Add a DID to an authority's registry"
+      ],
+      "accounts": [
         {
-          name: "registry",
-          isMut: true,
-          isSigner: false,
+          "name": "registry",
+          "isMut": true,
+          "isSigner": false
         },
         {
-          name: "authority",
-          isMut: false,
-          isSigner: true,
-          docs: ["The authority that owns the registry"],
+          "name": "authority",
+          "isMut": false,
+          "isSigner": true,
+          "docs": [
+            "The authority that owns the registry"
+          ]
         },
         {
-          name: "did",
-          isMut: false,
-          isSigner: false,
-          docs: [
-            'The DID to add to the registry. This is the did "identifier", not the did account',
+          "name": "did",
+          "isMut": false,
+          "isSigner": false,
+          "docs": [
+            "The DID to add to the registry. This is the did \"identifier\", not the did account",
             "i.e. did:sol:<identifier>",
-            "note - this may or may not be the same as the authority.",
-          ],
+            "note - this may or may not be the same as the authority."
+          ]
         },
         {
-          name: "didAccount",
-          isMut: false,
-          isSigner: false,
-          docs: [
+          "name": "didAccount",
+          "isMut": false,
+          "isSigner": false,
+          "docs": [
             "The account containing the DID document",
             "Specifically, the did account is checked to see if it has the authority as a signer",
-            "Since it can be a generative DID, we do not use Account<DidAccount> here",
-          ],
-        },
+            "Since it can be a generative DID, we do not use Account<DidAccount> here"
+          ]
+        }
       ],
-      args: [
+      "args": [
         {
-          name: "didBump",
-          type: "u8",
-        },
-      ],
+          "name": "didBump",
+          "type": "u8"
+        }
+      ]
     },
     {
-      name: "removeDid",
-      accounts: [
-        {
-          name: "registry",
-          isMut: true,
-          isSigner: false,
-        },
-        {
-          name: "authority",
-          isMut: false,
-          isSigner: true,
-          docs: ["The authority that owns the registry"],
-        },
-        {
-          name: "did",
-          isMut: false,
-          isSigner: false,
-          docs: ["The DID to remove from the registry"],
-        },
+      "name": "removeDid",
+      "docs": [
+        "Remove a DID from an authority's registry"
       ],
-      args: [],
+      "accounts": [
+        {
+          "name": "registry",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "authority",
+          "isMut": false,
+          "isSigner": true,
+          "docs": [
+            "The authority that owns the registry"
+          ]
+        },
+        {
+          "name": "did",
+          "isMut": false,
+          "isSigner": false,
+          "docs": [
+            "The DID to remove from the registry"
+          ]
+        }
+      ],
+      "args": []
     },
     {
-      name: "registerDidForEthAddress",
-      accounts: [
+      "name": "registerDidForEthAddress",
+      "docs": [
+        "Add a DID to an eth address's registry, if the solana signer is also an authority"
+      ],
+      "accounts": [
         {
-          name: "registry",
-          isMut: true,
-          isSigner: false,
+          "name": "registry",
+          "isMut": true,
+          "isSigner": false
         },
         {
-          name: "authority",
-          isMut: true,
-          isSigner: true,
+          "name": "authority",
+          "isMut": true,
+          "isSigner": true
         },
         {
-          name: "did",
-          isMut: false,
-          isSigner: false,
-          docs: [
-            'The DID to add to the registry. This is the did "identifier", not the did account',
+          "name": "did",
+          "isMut": false,
+          "isSigner": false,
+          "docs": [
+            "The DID to add to the registry. This is the did \"identifier\", not the did account",
             "i.e. did:sol:<identifier>",
-            "note - this may or may not be the same as the authority.",
-          ],
+            "note - this may or may not be the same as the authority."
+          ]
         },
         {
-          name: "didAccount",
-          isMut: false,
-          isSigner: false,
-          docs: [
+          "name": "didAccount",
+          "isMut": false,
+          "isSigner": false,
+          "docs": [
             "The account containing the DID document",
             "Specifically, the did account is checked to see if it has the authority as a signer",
-            "Since it can be a generative DID, we do not use Account<DidAccount> here",
-          ],
+            "Since it can be a generative DID, we do not use Account<DidAccount> here"
+          ]
         },
         {
-          name: "systemProgram",
-          isMut: false,
-          isSigner: false,
-        },
+          "name": "systemProgram",
+          "isMut": false,
+          "isSigner": false
+        }
       ],
-      args: [
+      "args": [
         {
-          name: "ethAddress",
-          type: {
-            array: ["u8", 20],
-          },
+          "name": "ethAddress",
+          "type": {
+            "array": [
+              "u8",
+              20
+            ]
+          }
         },
         {
-          name: "didBump",
-          type: "u8",
-        },
+          "name": "didBump",
+          "type": "u8"
+        }
+      ]
+    },
+    {
+      "name": "registerDidSignedByEthAddress",
+      "docs": [
+        "Add a DID to an eth address's registry, without requiring the solana signer to be an authority on the DID"
       ],
-    },
+      "accounts": [
+        {
+          "name": "registry",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "payer",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "did",
+          "isMut": false,
+          "isSigner": false,
+          "docs": [
+            "The DID to add to the registry. This is the did \"identifier\", not the did account",
+            "i.e. did:sol:<identifier>",
+            "note - this may or may not be the same as the payer."
+          ]
+        },
+        {
+          "name": "didAccount",
+          "isMut": false,
+          "isSigner": false,
+          "docs": [
+            "The account containing the DID document",
+            "This can safely be a DidAccount, rather than UncheckedAccount,",
+            "since, for the DID to include an eth address it must be a non-generative DID."
+          ]
+        },
+        {
+          "name": "systemProgram",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "ethAddress",
+          "type": {
+            "array": [
+              "u8",
+              20
+            ]
+          }
+        },
+        {
+          "name": "ethSignature",
+          "type": {
+            "defined": "Secp256k1RawSignature"
+          }
+        },
+        {
+          "name": "didBump",
+          "type": "u8"
+        }
+      ]
+    }
   ],
-  accounts: [
+  "accounts": [
     {
-      name: "keyRegistry",
-      type: {
-        kind: "struct",
-        fields: [
+      "name": "keyRegistry",
+      "type": {
+        "kind": "struct",
+        "fields": [
           {
-            name: "version",
-            type: "u8",
+            "name": "version",
+            "type": "u8"
           },
           {
-            name: "authority",
-            type: "publicKey",
+            "name": "authority",
+            "type": "publicKey"
           },
           {
-            name: "dids",
-            type: {
-              vec: "publicKey",
-            },
-          },
-        ],
-      },
+            "name": "dids",
+            "type": {
+              "vec": "publicKey"
+            }
+          }
+        ]
+      }
     },
     {
-      name: "controllerRegistry",
-      type: {
-        kind: "struct",
-        fields: [
+      "name": "controllerRegistry",
+      "type": {
+        "kind": "struct",
+        "fields": [
           {
-            name: "version",
-            type: "u8",
+            "name": "version",
+            "type": "u8"
           },
           {
-            name: "did",
-            type: "publicKey",
+            "name": "did",
+            "type": "publicKey"
           },
           {
-            name: "controlledDids",
-            type: {
-              vec: "publicKey",
-            },
-          },
-        ],
-      },
-    },
+            "name": "controlledDids",
+            "type": {
+              "vec": "publicKey"
+            }
+          }
+        ]
+      }
+    }
   ],
-  errors: [
+  "types": [
     {
-      code: 6000,
-      name: "DIDError",
-      msg: "An error occurred evaluating the DID",
-    },
-    {
-      code: 6001,
-      name: "NotAuthority",
-      msg: "The key is not an authority on the DID",
-    },
-    {
-      code: 6002,
-      name: "DIDRegistered",
-      msg: "The DID is already registered",
-    },
-    {
-      code: 6003,
-      name: "DIDNotRegistered",
-      msg: "Attempt to remove a DID that is not registered",
-    },
+      "name": "Secp256k1RawSignature",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "signature",
+            "type": {
+              "array": [
+                "u8",
+                64
+              ]
+            }
+          },
+          {
+            "name": "recoveryId",
+            "type": "u8"
+          }
+        ]
+      }
+    }
   ],
+  "errors": [
+    {
+      "code": 6000,
+      "name": "DIDError",
+      "msg": "An error occurred evaluating the DID"
+    },
+    {
+      "code": 6001,
+      "name": "NotAuthority",
+      "msg": "The key is not an authority on the DID"
+    },
+    {
+      "code": 6002,
+      "name": "DIDRegistered",
+      "msg": "The DID is already registered"
+    },
+    {
+      "code": 6003,
+      "name": "DIDNotRegistered",
+      "msg": "Attempt to remove a DID that is not registered"
+    },
+    {
+      "code": 6004,
+      "name": "InvalidEthSignature",
+      "msg": "The Eth signature did not sign the message"
+    },
+    {
+      "code": 6005,
+      "name": "WrongEthSigner",
+      "msg": "The Eth signature was signed by the wrong address"
+    }
+  ]
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -308,7 +308,7 @@
     "@ethersproject/constants" "^5.7.0"
     "@ethersproject/logger" "^5.7.0"
 
-"@ethersproject/wallet@5.7.0":
+"@ethersproject/wallet@5.7.0", "@ethersproject/wallet@^5.7.0":
   version "5.7.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/wallet/-/wallet-5.7.0.tgz#4e5d0790d96fe21d61d38fb40324e6c7ef350b2d"
   integrity sha512-MhmXlJXEJFBFVKrDLB4ZdDzxcBxQ3rLyCkhNqVu3CDYvR97E+8r01UgrI+TI99Le+aYm/in/0vp86guJuM7FCA==


### PR DESCRIPTION
New API:

ReadOnlyRegistry.for(solKey, connection)
ReadOnlyRegistry.forEthAddress(ethAddress, connection)

Registry.for(solWallet, connection)
EthRegistry.forEthAddress(ethAddress, solWallet, connection)

registry.register(did) // signs with sol wallet
ethRegistry.register(did) // signs with sol wallet ethRegistry.registerSigned(did) // signs with eth signer - sol wallet used for fees