### PR TITLE
Feature/separate payer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1121,7 +1121,7 @@ checksum = "2fd0db749597d91ff862fd1d55ea87f7855a744a8425a64695b6fca237d1dad1"
 [[package]]
 name = "sol-did"
 version = "3.1.4"
-source = "git+https://github.com/identity-com/sol-did?rev=642b2c45d6f2ece1668f44e715caece4d2b712d8#642b2c45d6f2ece1668f44e715caece4d2b712d8"
+source = "git+https://github.com/identity-com/sol-did?branch=feature/IDCOM-2102_controller_fixes#877d8b42d7406d22a47384b3beeb3bf3ffe99f1e"
 dependencies = [
  "anchor-lang",
  "bitflags",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@civic/did-registry",
-    "version": "0.0.6-alpha.2",
+    "version": "0.0.6",
     "description": "An on-chain protocol to provide reverse-lookup on did:sol key membership",
     "author": "Daniel Kelleher <daniel@civic.com>",
     "main": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@civic/did-registry",
-    "version": "0.0.5",
+    "version": "0.0.6-alpha.2",
     "description": "An on-chain protocol to provide reverse-lookup on did:sol key membership",
     "author": "Daniel Kelleher <daniel@civic.com>",
     "main": "dist/index.js",

--- a/programs/did-registry/Cargo.toml
+++ b/programs/did-registry/Cargo.toml
@@ -17,5 +17,5 @@ default = []
 
 [dependencies]
 anchor-lang = { version = "0.25.0", features = ["init-if-needed"] }
-sol-did = { git = "https://github.com/identity-com/sol-did", rev = "642b2c45d6f2ece1668f44e715caece4d2b712d8", features = ["no-entrypoint"] }
+sol-did = { git = "https://github.com/identity-com/sol-did", branch = "feature/IDCOM-2102_controller_fixes", features = ["no-entrypoint"] }
 itertools = "0.10.3"

--- a/programs/did-registry/src/instructions/close_controller_registry.rs
+++ b/programs/did-registry/src/instructions/close_controller_registry.rs
@@ -1,14 +1,36 @@
 use crate::state::controller_registry::ControllerRegistry;
+use crate::{SolDID, DID_ACCOUNT_SEED};
 use anchor_lang::prelude::*;
 
 #[derive(Accounts)]
+#[instruction(
+/// The bump seed for the did account
+did_bump: u8,
+)]
 pub struct CloseControllerRegistry<'info> {
     #[account(
     mut,
-    close = authority,
+    close = payer,
     )]
     pub registry: Account<'info, ControllerRegistry>,
     #[account(mut)]
+    pub payer: Signer<'info>,
+    #[account(mut)]
     pub authority: Signer<'info>,
+    /// The DID whose registry is being closed. This is the did "identifier", not the did account
+    /// i.e. did:sol:<identifier>
+    /// note - this may or may not be the same as the authority.
+    /// CHECK: This can be any public key. But it should derive the did_account
+    pub did: UncheckedAccount<'info>,
+    /// The account containing the DID document
+    /// CHECK: This is checked for correctness by the SolDid SDK
+    /// Specifically, the did account is checked to see if it has the authority as a signer
+    /// Since it can be a generative DID, we do not use Account<DidAccount> here
+    #[account(
+    seeds = [DID_ACCOUNT_SEED, did.key().as_ref()],
+    bump = did_bump,
+    seeds::program = SolDID::id()
+    )]
+    pub did_account: UncheckedAccount<'info>,
     pub system_program: Program<'info, System>,
 }

--- a/programs/did-registry/src/instructions/close_key_registry.rs
+++ b/programs/did-registry/src/instructions/close_key_registry.rs
@@ -5,9 +5,12 @@ use anchor_lang::prelude::*;
 pub struct CloseKeyRegistry<'info> {
     #[account(
     mut,
-    close = authority,
+    close = payer,
+    has_one = authority
     )]
     pub registry: Account<'info, KeyRegistry>,
+    #[account(mut)]
+    pub payer: Signer<'info>,
     #[account(mut)]
     pub authority: Signer<'info>,
     pub system_program: Program<'info, System>,

--- a/programs/did-registry/src/instructions/create_controller_registry.rs
+++ b/programs/did-registry/src/instructions/create_controller_registry.rs
@@ -12,12 +12,14 @@ did_bump: u8,
 pub struct CreateControllerRegistry<'info> {
     #[account(
     init,
-    payer = authority,
+    payer = payer,
     space = 8 + ControllerRegistry::INITIAL_SIZE,
     seeds = [ControllerRegistry::SEED_PREFIX, did.key().as_ref()],
     bump,
     )]
     pub registry: Account<'info, ControllerRegistry>,
+    #[account(mut)]
+    pub payer: Signer<'info>,
     #[account(mut)]
     pub authority: Signer<'info>,
     /// The DID to create the registry for. This is the did "identifier", not the did account

--- a/programs/did-registry/src/instructions/create_key_registry.rs
+++ b/programs/did-registry/src/instructions/create_key_registry.rs
@@ -5,12 +5,14 @@ use anchor_lang::prelude::*;
 pub struct CreateKeyRegistry<'info> {
     #[account(
     init,
-    payer = authority,
+    payer = payer,
     space = 8 + KeyRegistry::INITIAL_SIZE,
     seeds = [KeyRegistry::SEED_PREFIX, authority.key().as_ref()],
     bump,
     )]
     pub registry: Account<'info, KeyRegistry>,
+    #[account(mut)]
+    pub payer: Signer<'info>,
     #[account(mut)]
     pub authority: Signer<'info>,
     pub system_program: Program<'info, System>,

--- a/programs/did-registry/src/instructions/resize_controller_registry.rs
+++ b/programs/did-registry/src/instructions/resize_controller_registry.rs
@@ -9,12 +9,13 @@ pub struct ResizeControllerRegistry<'info> {
     seeds = [ControllerRegistry::SEED_PREFIX, authority.key().as_ref()],
     bump,
     realloc = TryInto::<usize>::try_into(ControllerRegistry::calculate_size(did_count)).unwrap(),
-    realloc::payer = authority,
+    realloc::payer = payer,
     realloc::zero = false,
-    // has_one = authority // TODO
     )]
     pub registry: Account<'info, ControllerRegistry>,
     #[account(mut)]
-    pub authority: Signer<'info>, // TODO prove ownership of did using did_sol
+    pub payer: Signer<'info>,
+    #[account(mut)]
+    pub authority: Signer<'info>, // ownership is proven in the program
     pub system_program: Program<'info, System>,
 }

--- a/programs/did-registry/src/instructions/resize_key_registry.rs
+++ b/programs/did-registry/src/instructions/resize_key_registry.rs
@@ -9,11 +9,13 @@ pub struct ResizeKeyRegistry<'info> {
     seeds = [KeyRegistry::SEED_PREFIX, authority.key().as_ref()],
     bump,
     realloc = TryInto::<usize>::try_into(KeyRegistry::calculate_size(did_count)).unwrap(),
-    realloc::payer = authority,
+    realloc::payer = payer,
     realloc::zero = false,
     has_one = authority
     )]
     pub registry: Account<'info, KeyRegistry>,
+    #[account(mut)]
+    pub payer: Signer<'info>,
     #[account(mut)]
     pub authority: Signer<'info>,
     pub system_program: Program<'info, System>,

--- a/programs/did-registry/src/lib.rs
+++ b/programs/did-registry/src/lib.rs
@@ -30,14 +30,14 @@ pub mod did_registry {
     }
 
     /// Add a DID to an authority's registry
-    pub fn register_did(ctx: Context<RegisterDid>, _did_bump: u8) -> Result<()> {
+    pub fn register_did(ctx: Context<RegisterDid>, did_bump: u8) -> Result<()> {
         // ensure the authority is an authority on the did account
         // note, anchor has already verified the constraint that did_account
         // is the account for the did.
         is_authority(
             &ctx.accounts.did_account.to_account_info(),
-            None, // the authority must be a direct authority on the DID
-            &[],
+            Some(did_bump),
+            &[], // the authority must be a direct authority on the DID
             ctx.accounts.authority.key().as_ref(),
             None,
             None,
@@ -90,13 +90,13 @@ pub mod did_registry {
     pub fn register_did_for_eth_address(
         ctx: Context<RegisterDidForEthAddress>,
         eth_address: [u8; 20],
-        _did_bump: u8,
+        did_bump: u8,
     ) -> Result<()> {
         // ensure the eth address is an authority on the DID
         is_authority(
             &ctx.accounts.did_account.to_account_info(),
-            None, // the authority must be a direct authority on the DID
-            &[],
+            Some(did_bump),
+            &[], // the authority must be a direct authority on the DID
             eth_address.as_ref(),
             None,
             None,
@@ -137,7 +137,7 @@ pub mod did_registry {
         ctx: Context<RegisterDidSignedByEthAddress>,
         eth_address: [u8; 20],
         eth_signature: Secp256k1RawSignature,
-        _did_bump: u8,
+        did_bump: u8,
     ) -> Result<()> {
         // Check the eth signature is a signature of the DID identifier as a byte array
         // and that it was signed by the eth address
@@ -154,7 +154,7 @@ pub mod did_registry {
         // is the account for the did.
         is_authority(
             &ctx.accounts.did_account.to_account_info(),
-            None,
+            Some(did_bump),
             &[], // the authority must be a direct authority on the DID
             eth_address.as_ref(),
             None,
@@ -194,14 +194,9 @@ pub mod did_registry {
     /// Create an empty controller registry for a given DID
     pub fn create_controller_registry(
         ctx: Context<CreateControllerRegistry>,
-        _bump: u8,
-        _did_bump: u8,
+        _bump: u8,    // the registry PDA bump
+        did_bump: u8, // the DID account PDA bump
     ) -> Result<()> {
-        msg!(
-            "Creating controller registry for did {}",
-            ctx.accounts.did.key()
-        );
-        msg!("Controller registry: {}", ctx.accounts.registry.key());
         ctx.accounts.registry.did = ctx.accounts.did.key();
 
         // ensure the authority is an authority on the did account that the registry is being created for
@@ -211,7 +206,7 @@ pub mod did_registry {
         // but to prevent any future exploits, we lock it down here to a DID authority.
         is_authority(
             &ctx.accounts.did_account.to_account_info(),
-            None, // the authority must be a direct authority on the DID
+            Some(did_bump), // the authority must be a direct authority on the DID
             &[],
             ctx.accounts.authority.key().as_ref(),
             None,
@@ -227,7 +222,7 @@ pub mod did_registry {
     /// Add a controlled DID to an authority's controller registry
     pub fn register_controlled_did(
         ctx: Context<RegisterControlledDid>,
-        _did_bump: u8,
+        did_bump: u8,
         _controlled_did_bump: u8,
     ) -> Result<()> {
         msg!(
@@ -242,8 +237,8 @@ pub mod did_registry {
         // is the account for the registry's did.
         is_authority(
             &ctx.accounts.did_account.to_account_info(),
-            None, // the authority must be a direct authority on the DID
-            &[],
+            Some(did_bump),
+            &[], // the authority must be a direct authority on the DID
             ctx.accounts.authority.key().as_ref(),
             None,
             None,
@@ -256,14 +251,14 @@ pub mod did_registry {
         let controlled_did = &ctx.accounts.controlled_did;
 
         let controller_account_info_and_pubkey = &(
-            ctx.accounts.did_account.to_account_info(),
+            &ctx.accounts.did_account.to_account_info(),
             ctx.accounts.registry.did,
         );
         let controller_did_data =
             DidAccount::try_from_or_default(controller_account_info_and_pubkey)?;
 
         let controlled_account_info_and_pubkey = &(
-            ctx.accounts.controlled_did_account.to_account_info(),
+            &ctx.accounts.controlled_did_account.to_account_info(),
             ctx.accounts.controlled_did.key(),
         );
         let controlled_did_data =
@@ -313,7 +308,7 @@ pub mod did_registry {
     }
 
     /// Remove a controlled DID from a controller registry
-    pub fn remove_controlled_did(ctx: Context<RemoveControlledDid>, _did_bump: u8) -> Result<()> {
+    pub fn remove_controlled_did(ctx: Context<RemoveControlledDid>, did_bump: u8) -> Result<()> {
         let did_to_remove = &ctx.accounts.did_to_remove.key();
 
         // ensure the authority is an authority on the did account that the registry is being created for
@@ -323,7 +318,7 @@ pub mod did_registry {
         // but to prevent any future exploits, we lock it down here to a DID authority.
         is_authority(
             &ctx.accounts.did_account.to_account_info(),
-            None, // the authority must be a direct authority on the DID
+            Some(did_bump), // the authority must be a direct authority on the DID
             &[],
             ctx.accounts.authority.key().as_ref(),
             None,
@@ -363,14 +358,14 @@ pub mod did_registry {
 
     pub fn close_controller_registry(
         ctx: Context<CloseControllerRegistry>,
-        _did_bump: u8,
+        did_bump: u8,
     ) -> Result<()> {
         // ensure the authority is an authority on the did account whose registry is being closed
         // note, anchor has already verified the constraint that did_account
         // is the account for the did.
         is_authority(
             &ctx.accounts.did_account.to_account_info(),
-            None,
+            Some(did_bump),
             &[], // the authority must be a direct authority on the DID
             ctx.accounts.authority.key().as_ref(),
             None,

--- a/programs/did-registry/src/lib.rs
+++ b/programs/did-registry/src/lib.rs
@@ -361,7 +361,25 @@ pub mod did_registry {
         Ok(())
     }
 
-    pub fn close_controller_registry(_ctx: Context<CloseControllerRegistry>) -> Result<()> {
+    pub fn close_controller_registry(
+        ctx: Context<CloseControllerRegistry>,
+        _did_bump: u8,
+    ) -> Result<()> {
+        // ensure the authority is an authority on the did account whose registry is being closed
+        // note, anchor has already verified the constraint that did_account
+        // is the account for the did.
+        is_authority(
+            &ctx.accounts.did_account.to_account_info(),
+            None,
+            &[], // the authority must be a direct authority on the DID
+            ctx.accounts.authority.key().as_ref(),
+            None,
+            None,
+        )
+        .map_err(|_| ErrorCode::DIDError)?
+        .then_some(())
+        .ok_or(ErrorCode::NotAuthority)?;
+
         Ok(())
     }
 }

--- a/src/types/did_registry.ts
+++ b/src/types/did_registry.ts
@@ -14,6 +14,11 @@ export type DidRegistry = {
           "isSigner": false
         },
         {
+          "name": "payer",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
           "name": "authority",
           "isMut": true,
           "isSigner": true
@@ -239,6 +244,11 @@ export type DidRegistry = {
           "isSigner": false
         },
         {
+          "name": "payer",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
           "name": "authority",
           "isMut": true,
           "isSigner": true
@@ -265,6 +275,11 @@ export type DidRegistry = {
           "isSigner": false
         },
         {
+          "name": "payer",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
           "name": "authority",
           "isMut": true,
           "isSigner": true
@@ -287,6 +302,11 @@ export type DidRegistry = {
           "name": "registry",
           "isMut": true,
           "isSigner": false
+        },
+        {
+          "name": "payer",
+          "isMut": true,
+          "isSigner": true
         },
         {
           "name": "authority",
@@ -446,6 +466,11 @@ export type DidRegistry = {
           "isSigner": false
         },
         {
+          "name": "payer",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
           "name": "authority",
           "isMut": true,
           "isSigner": true
@@ -472,9 +497,34 @@ export type DidRegistry = {
           "isSigner": false
         },
         {
+          "name": "payer",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
           "name": "authority",
           "isMut": true,
           "isSigner": true
+        },
+        {
+          "name": "did",
+          "isMut": false,
+          "isSigner": false,
+          "docs": [
+            "The DID whose registry is being closed. This is the did \"identifier\", not the did account",
+            "i.e. did:sol:<identifier>",
+            "note - this may or may not be the same as the authority."
+          ]
+        },
+        {
+          "name": "didAccount",
+          "isMut": false,
+          "isSigner": false,
+          "docs": [
+            "The account containing the DID document",
+            "Specifically, the did account is checked to see if it has the authority as a signer",
+            "Since it can be a generative DID, we do not use Account<DidAccount> here"
+          ]
         },
         {
           "name": "systemProgram",
@@ -482,7 +532,12 @@ export type DidRegistry = {
           "isSigner": false
         }
       ],
-      "args": []
+      "args": [
+        {
+          "name": "didBump",
+          "type": "u8"
+        }
+      ]
     }
   ],
   "accounts": [
@@ -614,6 +669,11 @@ export const IDL: DidRegistry = {
           "isSigner": false
         },
         {
+          "name": "payer",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
           "name": "authority",
           "isMut": true,
           "isSigner": true
@@ -839,6 +899,11 @@ export const IDL: DidRegistry = {
           "isSigner": false
         },
         {
+          "name": "payer",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
           "name": "authority",
           "isMut": true,
           "isSigner": true
@@ -865,6 +930,11 @@ export const IDL: DidRegistry = {
           "isSigner": false
         },
         {
+          "name": "payer",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
           "name": "authority",
           "isMut": true,
           "isSigner": true
@@ -887,6 +957,11 @@ export const IDL: DidRegistry = {
           "name": "registry",
           "isMut": true,
           "isSigner": false
+        },
+        {
+          "name": "payer",
+          "isMut": true,
+          "isSigner": true
         },
         {
           "name": "authority",
@@ -1046,6 +1121,11 @@ export const IDL: DidRegistry = {
           "isSigner": false
         },
         {
+          "name": "payer",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
           "name": "authority",
           "isMut": true,
           "isSigner": true
@@ -1072,9 +1152,34 @@ export const IDL: DidRegistry = {
           "isSigner": false
         },
         {
+          "name": "payer",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
           "name": "authority",
           "isMut": true,
           "isSigner": true
+        },
+        {
+          "name": "did",
+          "isMut": false,
+          "isSigner": false,
+          "docs": [
+            "The DID whose registry is being closed. This is the did \"identifier\", not the did account",
+            "i.e. did:sol:<identifier>",
+            "note - this may or may not be the same as the authority."
+          ]
+        },
+        {
+          "name": "didAccount",
+          "isMut": false,
+          "isSigner": false,
+          "docs": [
+            "The account containing the DID document",
+            "Specifically, the did account is checked to see if it has the authority as a signer",
+            "Since it can be a generative DID, we do not use Account<DidAccount> here"
+          ]
         },
         {
           "name": "systemProgram",
@@ -1082,7 +1187,12 @@ export const IDL: DidRegistry = {
           "isSigner": false
         }
       ],
-      "args": []
+      "args": [
+        {
+          "name": "didBump",
+          "type": "u8"
+        }
+      ]
     }
   ],
   "accounts": [

--- a/tests/ControllerRegistry.ts
+++ b/tests/ControllerRegistry.ts
@@ -1,24 +1,14 @@
 import * as anchor from "@project-serum/anchor";
 import { Program } from "@project-serum/anchor";
 import { Keypair } from "@solana/web3.js";
-import { Wallet as EthWallet } from "@ethersproject/wallet";
 import { ControllerRegistry, ReadOnlyControllerRegistry } from "../src";
 
 import { DidRegistry } from "../target/types/did_registry";
 import chai from "chai";
 import chaiAsPromised from "chai-as-promised";
-import {
-  addEthAddressToDID,
-  addKeyToDID,
-  createDIDAndAddController,
-  createDIDAndAddKey,
-  initializeDIDAccount,
-  toDid,
-} from "./util/did";
-import { createTestContext, fund } from "./util/anchorUtils";
+import { createDIDAndAddController, toDid } from "./util/did";
 import {
   DidSolIdentifier,
-  DidSolService,
   ExtendedCluster,
 } from "@identity.com/sol-did-client";
 import { times } from "./util/lang";
@@ -52,7 +42,8 @@ describe("Controller Registry", () => {
       .close()
       .rpc()
       .catch((error) => {
-        if (error.error.errorCode.code === "AccountNotInitialized") {
+        // anchor errors have this fun property structure...
+        if (error?.error?.errorCode?.code === "AccountNotInitialized") {
           // ignore - the test does not need the registry to be created
           return;
         }


### PR DESCRIPTION
Allow setting a rent payer separate to the did registry authority.
Fix a security bug relating to closing a controller registry
Potentially optimise all is-authority checks by providing the did-bump.