### PR TITLE
CI: Github actions update

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -29,10 +29,9 @@ jobs:
         with:
           node-version: '16'
 
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: stable
-          override: true
 
       - name: Cache rust
         uses: Swatinem/rust-cache@v2


### PR DESCRIPTION
Replacing actions-rs which is stuck on Node 12 and not updated for 2 years, with a more active Github action